### PR TITLE
DXP-1310 Implement method to retrieve channel schema in PHP Ingestion Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $message = (Message::newPublishMessage('index.html', $pageData))
 $pagesPublisher->send($message);
 
 // The Publisher enables you to retrieve the channel schema (as Json String) by invoking the following method:
-$pagesPublisher->getSchema();
+$pagesPublisher->fetchSchema();
 ```
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ As of 2024-11-07, the supported version of StreamX is 0.0.45.
 - [StreamxClientBuilders](src/Builders/StreamxClientBuilders.php) - with which it's possible to
   create default or customized clients,
 - [StreamxClient](src/StreamxClient.php) - with which it's possible to create publishers
-- [Publisher](src/Publisher/Publisher.php) - with which it's possible to make actual publications
+- [Publisher](src/Publisher/Publisher.php) - with which it's possible to make actual ingestions (publishing and unpublishing)
 
 # Example usage:
 
@@ -62,6 +62,9 @@ $message = (Message::newPublishMessage('index.html', $pageData))
     ->withProperties(['prop-1' => 'value-1', 'prop-2' => 'value-2'])
     ->build();
 $pagesPublisher->send($message);
+
+// The Publisher enables you to retrieve the channel schema (as Json String) by invoking the following method:
+$pagesPublisher->getSchema();
 ```
 
 # Installation

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "streamx/ingestion-client",
   "description": "PHP ingestion client for StreamX - a Digital Experience Data Mesh.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "library",
   "autoload": {
     "psr-4": {

--- a/src/Impl/GuzzleHttpRequester.php
+++ b/src/Impl/GuzzleHttpRequester.php
@@ -24,7 +24,7 @@ class GuzzleHttpRequester implements HttpRequester
         $this->httpClient = $httpClient ?? new GuzzleHttpClient();
     }
 
-    public function executeIngestionRequest(
+    public function performIngestion(
         UriInterface $endpointUri,
         array $headers,
         string $json
@@ -40,7 +40,7 @@ class GuzzleHttpRequester implements HttpRequester
         }
     }
 
-    public function executeSchemaRequest(
+    public function fetchSchema(
         UriInterface $endpointUri,
         array $headers
     ): string {

--- a/src/Impl/GuzzleHttpRequester.php
+++ b/src/Impl/GuzzleHttpRequester.php
@@ -24,7 +24,7 @@ class GuzzleHttpRequester implements HttpRequester
         $this->httpClient = $httpClient ?? new GuzzleHttpClient();
     }
 
-    public function executePost(
+    public function executeIngestionRequest(
         UriInterface $endpointUri,
         array $headers,
         string $json
@@ -32,10 +32,25 @@ class GuzzleHttpRequester implements HttpRequester
         try {
             $request = new Request('POST', $endpointUri, $headers, $json);
             $response = $this->httpClient->sendRequest($request);
-            return $this->handleResponse($response);
+            return $this->handleIngestionResponse($response);
         } catch (ClientExceptionInterface $e) {
             throw new StreamxClientException(
-                sprintf('POST request with URI: %s failed due to HTTP client error', $endpointUri),
+                sprintf('Ingestion POST request with URI: %s failed due to HTTP client error', $endpointUri),
+                $e);
+        }
+    }
+
+    public function executeSchemaRequest(
+        UriInterface $endpointUri,
+        array $headers
+    ): string {
+        try {
+            $request = new Request('GET', $endpointUri, $headers);
+            $response = $this->httpClient->sendRequest($request);
+            return $this->handleSchemaResponse($response);
+        } catch (ClientExceptionInterface $e) {
+            throw new StreamxClientException(
+                sprintf('Schema GET request with URI: %s failed due to HTTP client error', $endpointUri),
                 $e);
         }
     }
@@ -44,27 +59,37 @@ class GuzzleHttpRequester implements HttpRequester
      * @return MessageStatus[]
      * @throws StreamxClientException
      */
-    private function handleResponse(ResponseInterface $response): array
+    private function handleIngestionResponse(ResponseInterface $response): array
     {
         $statusCode = $response->getStatusCode();
 
-        if ($statusCode == 202) {
-            return $this->parseMessageStatuses($response);
+        switch ($statusCode) {
+            case 202:
+                return $this->parseMessageStatuses($response);
+            case 401:
+                throw $this->createAuthenticationException();
+            case in_array($statusCode, [400, 403, 500]):
+                $failureResponse = $this->parseFailureResponse($response);
+                throw $this->streamxClientExceptionFrom($failureResponse);
+            default:
+                throw $this->createGenericCommunicationException($response);
         }
+    }
 
-        if ($statusCode == 401) {
-            throw new StreamxClientException('Authentication failed. Make sure that the given token is valid.');
+    /**
+     * @throws StreamxClientException
+     */
+    private function handleSchemaResponse(ResponseInterface $response): string
+    {
+        $statusCode = $response->getStatusCode();
+        switch ($statusCode) {
+            case 200:
+                return (string)$response->getBody();
+            case 401:
+                throw $this->createAuthenticationException();
+            default:
+                throw $this->createGenericCommunicationException($response);
         }
-
-        if (in_array($statusCode, [400, 403, 500])) {
-            $failureResponse = $this->parseFailureResponse($response);
-            throw $this->streamxClientExceptionFrom($failureResponse);
-        }
-
-        throw new StreamxClientException(
-            sprintf('Communication error. Response status: %s. Message: %s',
-                $statusCode,
-                $response->getReasonPhrase()));
     }
 
     /**
@@ -132,5 +157,18 @@ class GuzzleHttpRequester implements HttpRequester
                 $response->getStatusCode(), 'Response could not be parsed.'));
         }
         return $jsonObject;
+    }
+
+    private static function createAuthenticationException(): StreamxClientException
+    {
+        return new StreamxClientException('Authentication failed. Make sure that the given token is valid.');
+    }
+
+    private static function createGenericCommunicationException(ResponseInterface $response): StreamxClientException
+    {
+        return new StreamxClientException(
+            sprintf('Communication error. Response status: %s. Message: %s',
+                $response->getStatusCode(),
+                $response->getReasonPhrase()));
     }
 }

--- a/src/Impl/RestPublisher.php
+++ b/src/Impl/RestPublisher.php
@@ -74,12 +74,12 @@ class RestPublisher extends Publisher
         }
 
         $actualHeaders = array_merge($this->headers, ['Content-Type' => 'application/json; charset=UTF-8']);
-        return $this->httpRequester->executeIngestionRequest($this->ingestionEndpointUri, $actualHeaders, $multiMessageJson);
+        return $this->httpRequester->performIngestion($this->ingestionEndpointUri, $actualHeaders, $multiMessageJson);
     }
 
-    public function getSchema(): string
+    public function fetchSchema(): string
     {
-        return $this->httpRequester->executeSchemaRequest($this->schemaEndpointUri, $this->headers);
+        return $this->httpRequester->fetchSchema($this->schemaEndpointUri, $this->headers);
     }
 
     private function buildHttpHeaders(?string $authToken): array

--- a/src/Impl/RestPublisher.php
+++ b/src/Impl/RestPublisher.php
@@ -15,14 +15,18 @@ use Streamx\Clients\Ingestion\Publisher\SuccessResult;
 
 class RestPublisher extends Publisher
 {
+    private const INGESTION_ENDPOINT_RELATIVE_PATH = "channels/[CHANNEL]/messages";
+    private const SCHEMA_ENDPOINT_RELATIVE_PATH = "channels/[CHANNEL]/schema";
+
     private array $headers;
-    private UriInterface $messageIngestionEndpointUri;
+    private UriInterface $ingestionEndpointUri;
+    private UriInterface $schemaEndpointUri;
     private string $payloadTypeName;
     private HttpRequester $httpRequester;
     private JsonProvider $jsonProvider;
 
     public function __construct(
-        UriInterface $ingestionEndpointUri,
+        UriInterface $ingestionEndpointBaseUri,
         string $channel,
         string $channelSchemaName,
         ?string $authToken,
@@ -30,7 +34,8 @@ class RestPublisher extends Publisher
         JsonProvider $jsonProvider
     ) {
         $this->headers = $this->buildHttpHeaders($authToken);
-        $this->messageIngestionEndpointUri = $this->buildMessageIngestionUri($ingestionEndpointUri, $channel);
+        $this->ingestionEndpointUri = self::buildUri($ingestionEndpointBaseUri, self::INGESTION_ENDPOINT_RELATIVE_PATH, $channel);
+        $this->schemaEndpointUri = self::buildUri($ingestionEndpointBaseUri, self::SCHEMA_ENDPOINT_RELATIVE_PATH, $channel);
         $this->payloadTypeName = self::convertToPayloadTypeName($channelSchemaName);
         $this->httpRequester = $httpRequester;
         $this->jsonProvider = $jsonProvider;
@@ -69,7 +74,12 @@ class RestPublisher extends Publisher
         }
 
         $actualHeaders = array_merge($this->headers, ['Content-Type' => 'application/json; charset=UTF-8']);
-        return $this->httpRequester->executePost($this->messageIngestionEndpointUri, $actualHeaders, $multiMessageJson);
+        return $this->httpRequester->executeIngestionRequest($this->ingestionEndpointUri, $actualHeaders, $multiMessageJson);
+    }
+
+    public function getSchema(): string
+    {
+        return $this->httpRequester->executeSchemaRequest($this->schemaEndpointUri, $this->headers);
     }
 
     private function buildHttpHeaders(?string $authToken): array
@@ -83,8 +93,9 @@ class RestPublisher extends Publisher
     /**
      * @throws StreamxClientException
      */
-    private function buildMessageIngestionUri(UriInterface $ingestionEndpointUri, string $channel): UriInterface
+    private static function buildUri(UriInterface $ingestionEndpointBaseUri, string $relativePath, string $channel): UriInterface
     {
-        return HttpUtils::buildUri("$ingestionEndpointUri/channels/$channel/messages");
+        $uriString = str_replace('[CHANNEL]', $channel, "$ingestionEndpointBaseUri/$relativePath");
+        return HttpUtils::buildUri($uriString);
     }
 }

--- a/src/Impl/RestPublisherProvider.php
+++ b/src/Impl/RestPublisherProvider.php
@@ -10,18 +10,18 @@ use Streamx\Clients\Ingestion\Publisher\Publisher;
 class RestPublisherProvider
 {
 
-    private UriInterface $ingestionEndpointUri;
+    private UriInterface $ingestionEndpointBaseUri;
     private ?string $authToken;
     private HttpRequester $httpRequester;
     private JsonProvider $jsonProvider;
 
     public function __construct(
-        UriInterface $ingestionEndpointUri,
+        UriInterface $ingestionEndpointBaseUri,
         ?string $authToken,
         HttpRequester $httpRequester,
         JsonProvider $jsonProvider)
     {
-        $this->ingestionEndpointUri = $ingestionEndpointUri;
+        $this->ingestionEndpointBaseUri = $ingestionEndpointBaseUri;
         $this->authToken = $authToken;
         $this->httpRequester = $httpRequester;
         $this->jsonProvider = $jsonProvider;
@@ -30,7 +30,7 @@ class RestPublisherProvider
     public function newPublisher(string $channel, string $channelSchemaName): Publisher
     {
         return new RestPublisher(
-            $this->ingestionEndpointUri,
+            $this->ingestionEndpointBaseUri,
             $channel,
             $channelSchemaName,
             $this->authToken,

--- a/src/Impl/RestStreamxClientBuilder.php
+++ b/src/Impl/RestStreamxClientBuilder.php
@@ -11,7 +11,7 @@ use Streamx\Clients\Ingestion\StreamxClientBuilder;
 class RestStreamxClientBuilder implements StreamxClientBuilder
 {
     private string $serverUrl;
-    private ?string $ingestionEndpointUri = null;
+    private ?string $ingestionEndpointBaseUri = null;
     private ?string $authToken = null;
     private ?HttpRequester $httpRequester = null;
     private ?ClientInterface $httpClient = null;
@@ -22,9 +22,9 @@ class RestStreamxClientBuilder implements StreamxClientBuilder
         $this->serverUrl = $serverUrl;
     }
 
-    public function setIngestionEndpointUri(string $ingestionEndpointUri): StreamxClientBuilder
+    public function setIngestionEndpointBaseUri(string $ingestionEndpointBaseUri): StreamxClientBuilder
     {
-        $this->ingestionEndpointUri = $ingestionEndpointUri;
+        $this->ingestionEndpointBaseUri = $ingestionEndpointBaseUri;
         return $this;
     }
 
@@ -57,14 +57,14 @@ class RestStreamxClientBuilder implements StreamxClientBuilder
         $this->ensureIngestionEndpointUri();
         $this->ensureHttpRequester();
         $this->ensureJsonProvider();
-        return new RestStreamxClient($this->serverUrl, $this->ingestionEndpointUri,
+        return new RestStreamxClient($this->serverUrl, $this->ingestionEndpointBaseUri,
             $this->authToken, $this->httpRequester, $this->jsonProvider);
     }
 
     private function ensureIngestionEndpointUri(): void
     {
-        if ($this->ingestionEndpointUri == null) {
-            $this->ingestionEndpointUri = StreamxClient::INGESTION_ENDPOINT_PATH_V1;
+        if ($this->ingestionEndpointBaseUri == null) {
+            $this->ingestionEndpointBaseUri = StreamxClient::INGESTION_ENDPOINT_BASE_PATH;
         }
     }
 

--- a/src/Publisher/HttpRequester.php
+++ b/src/Publisher/HttpRequester.php
@@ -19,7 +19,7 @@ interface HttpRequester
      * @return MessageStatus[] with SuccessResult and/or FailureResponse of processing messages in the request
      * @throws StreamxClientException if request failed.
      */
-    public function executeIngestionRequest(
+    public function performIngestion(
         UriInterface $endpointUri,
         array $headers,
         string $json
@@ -32,7 +32,7 @@ interface HttpRequester
      * @return string response of the endpoint.
      * @throws StreamxClientException if request failed.
      */
-    public function executeSchemaRequest(
+    public function fetchSchema(
         UriInterface $endpointUri,
         array $headers
     ): string;

--- a/src/Publisher/HttpRequester.php
+++ b/src/Publisher/HttpRequester.php
@@ -12,16 +12,28 @@ use Streamx\Clients\Ingestion\Impl\MessageStatus;
 interface HttpRequester
 {
     /**
-     * Performs POST request.
+     * Executes a StreamX Ingestion POST request.
      * @param UriInterface $endpointUri Request target URI.
      * @param array $headers Request headers.
      * @param string $json Request JSON.
      * @return MessageStatus[] with SuccessResult and/or FailureResponse of processing messages in the request
      * @throws StreamxClientException if request failed.
      */
-    public function executePost(
+    public function executeIngestionRequest(
         UriInterface $endpointUri,
         array $headers,
         string $json
     ): array;
+
+    /**
+     * Executes a StreamX Schema GET request.
+     * @param UriInterface $endpointUri Request target URI.
+     * @param array $headers Request headers.
+     * @return string response of the endpoint.
+     * @throws StreamxClientException if request failed.
+     */
+    public function executeSchemaRequest(
+        UriInterface $endpointUri,
+        array $headers
+    ): string;
 }

--- a/src/Publisher/Publisher.php
+++ b/src/Publisher/Publisher.php
@@ -55,5 +55,5 @@ abstract class Publisher
     /**
      * @return string schema of the Publisher's channel
      */
-    public abstract function getSchema(): string;
+    public abstract function fetchSchema(): string;
 }

--- a/src/Publisher/Publisher.php
+++ b/src/Publisher/Publisher.php
@@ -6,15 +6,15 @@ use Streamx\Clients\Ingestion\Exceptions\StreamxClientException;
 use Streamx\Clients\Ingestion\Impl\MessageStatus;
 
 /**
- * StreamX publications ingestion endpoint contract. `Publisher` instance is reusable.
+ * StreamX ingestion endpoint contract. `Publisher` instance is reusable.
  */
 abstract class Publisher
 {
 
     /**
-     * Performs publications ingestion endpoint `publish` command.
-     * @param string $key Publication key.
-     * @param array|object $payload Publication payload.
+     * Performs ingestion endpoint `publish` command.
+     * @param string $key Publish key.
+     * @param array|object $payload Publish payload.
      * @return SuccessResult containing ingestion endpoint response entity.
      * @throws StreamxClientException if command failed.
      */
@@ -25,8 +25,8 @@ abstract class Publisher
     }
 
     /**
-     * Performs publications ingestion endpoint `unpublish` command.
-     * @param string $key Publication key.
+     * Performs ingestion endpoint `unpublish` command.
+     * @param string $key Unpublish key.
      * @return SuccessResult containing ingestion endpoint response entity.
      * @throws StreamxClientException if command failed.
      */
@@ -51,4 +51,9 @@ abstract class Publisher
      * @throws StreamxClientException If a critical error occurred and the MessageStatus[] with SuccessResult and/or FailureResponse cannot be returned.
      */
     public abstract function sendMulti(array $messages): array;
+
+    /**
+     * @return string schema of the Publisher's channel
+     */
+    public abstract function getSchema(): string;
 }

--- a/src/StreamxClient.php
+++ b/src/StreamxClient.php
@@ -5,14 +5,14 @@ namespace Streamx\Clients\Ingestion;
 use Streamx\Clients\Ingestion\Publisher\Publisher;
 
 /**
- * Represents a client that can make publications to StreamX Ingestion Service.
+ * Represents a client that can communicate with StreamX Ingestion Service.
  */
 interface StreamxClient
 {
     /**
-     * StreamX REST Ingestion publications path.
+     * StreamX REST Ingestion base path.
      */
-    public const INGESTION_ENDPOINT_PATH_V1 = '/ingestion/v1';
+    public const INGESTION_ENDPOINT_BASE_PATH = '/ingestion/v1';
 
     /**
      * Creates new {@link Publisher} instance.

--- a/src/StreamxClientBuilder.php
+++ b/src/StreamxClientBuilder.php
@@ -14,12 +14,12 @@ interface StreamxClientBuilder
 {
 
     /**
-     * Configures custom StreamX REST Ingestion publication path. Default value is
-     * {@link StreamxClient::INGESTION_ENDPOINT_PATH_V1}.
-     * @param string $ingestionEndpointUri StreamX REST Ingestion publication path.
+     * Configures custom StreamX REST Ingestion base path. Default value is
+     * {@link StreamxClient::INGESTION_ENDPOINT_BASE_PATH}.
+     * @param string $ingestionEndpointBaseUri StreamX REST Ingestion base path.
      * @return StreamxClientBuilder
      */
-    public function setIngestionEndpointUri(string $ingestionEndpointUri
+    public function setIngestionEndpointBaseUri(string $ingestionEndpointBaseUri
     ): StreamxClientBuilder;
 
     /**

--- a/tests/Testing/Impl/CustomTestHttpRequester.php
+++ b/tests/Testing/Impl/CustomTestHttpRequester.php
@@ -20,13 +20,13 @@ class CustomTestHttpRequester implements HttpRequester
         $this->httpRequester = new GuzzleHttpRequester();
     }
 
-    public function executeIngestionRequest(
+    public function performIngestion(
         UriInterface $endpointUri,
         array $headers,
         string $json
     ): array {
         $endpointUri = $this->modifyUri($endpointUri);
-        return $this->httpRequester->executeIngestionRequest($endpointUri, $headers, $json);
+        return $this->httpRequester->performIngestion($endpointUri, $headers, $json);
     }
 
     private function modifyUri(UriInterface $uri): UriInterface
@@ -37,8 +37,8 @@ class CustomTestHttpRequester implements HttpRequester
         );
     }
 
-    public function executeSchemaRequest(UriInterface $endpointUri, array $headers): string
+    public function fetchSchema(UriInterface $endpointUri, array $headers): string
     {
-        return $this->httpRequester->executeSchemaRequest($endpointUri, $headers);
+        return $this->httpRequester->fetchSchema($endpointUri, $headers);
     }
 }

--- a/tests/Testing/Impl/CustomTestHttpRequester.php
+++ b/tests/Testing/Impl/CustomTestHttpRequester.php
@@ -20,20 +20,25 @@ class CustomTestHttpRequester implements HttpRequester
         $this->httpRequester = new GuzzleHttpRequester();
     }
 
-    public function executePost(
+    public function executeIngestionRequest(
         UriInterface $endpointUri,
         array $headers,
         string $json
     ): array {
         $endpointUri = $this->modifyUri($endpointUri);
-        return $this->httpRequester->executePost($endpointUri, $headers, $json);
+        return $this->httpRequester->executeIngestionRequest($endpointUri, $headers, $json);
     }
 
     private function modifyUri(UriInterface $uri): UriInterface
     {
         return $uri->withPath(
-            str_replace(StreamxClient::INGESTION_ENDPOINT_PATH_V1,
+            str_replace(StreamxClient::INGESTION_ENDPOINT_BASE_PATH,
                 $this->ingestionEndpointPath, $uri->getPath())
         );
+    }
+
+    public function executeSchemaRequest(UriInterface $endpointUri, array $headers): string
+    {
+        return $this->httpRequester->executeSchemaRequest($endpointUri, $headers);
     }
 }

--- a/tests/Testing/MockServerTestCase.php
+++ b/tests/Testing/MockServerTestCase.php
@@ -56,26 +56,48 @@ class MockServerTestCase extends TestCase
         return '{"key":"'.$key.'","action":"unpublish","eventTime":null,"properties":{},"payload":null}';
     }
 
-    protected function assertIngestionPostRequest(
+    protected function assertIngestionRequest(
         RequestInfo $request,
         string $uri,
         string $expectedBody,
         array $headers = null
     ): void {
-        $this->assertEquals('POST', $request->getRequestMethod());
+        $this->assertRequest($request, 'POST', $uri, $expectedBody, $headers);
+    }
+
+    protected function assertSchemaRequest(
+        RequestInfo $request,
+        string $uri,
+        array $headers = null
+    ): void {
+        $this->assertRequest($request, 'GET', $uri, null, $headers);
+    }
+
+    private function assertRequest(
+        RequestInfo $request,
+        string $expectedMethod,
+        string $uri,
+        ?string $expectedBody,
+        array $headers = null
+    ): void {
+        $this->assertEquals($expectedMethod, $request->getRequestMethod());
         $this->assertEquals($uri, $request->getRequestUri());
         $this->assertEquals($expectedBody, $request->getInput());
-        $this->assertEquals('application/json; charset=UTF-8', $request->getHeaders()['Content-Type']);
+        if ($expectedMethod === 'GET') {
+            $this->assertNotContains('Content-Type', array_keys($request->getHeaders()));
+        } else {
+            $this->assertEquals('application/json; charset=UTF-8', $request->getHeaders()['Content-Type']);
+        }
         $this->assertHeaders($request, $headers);
     }
 
-    protected function assertHeaders(RequestInfo $request, ?array $headers): void
+    private function assertHeaders(RequestInfo $request, ?array $expectedHeaders): void
     {
-        if ($headers == null) {
-            return;
-        }
-        foreach ($headers as $name => $value) {
-            $this->assertEquals($value, $request->getHeaders()[$name]);
+        if ($expectedHeaders) {
+            $requestHeaders = $request->getHeaders();
+            foreach ($expectedHeaders as $name => $value) {
+                $this->assertEquals($value, $requestHeaders[$name]);
+            }
         }
     }
 }

--- a/tests/Unit/Impl/RestStreamxClientBuilderTest.php
+++ b/tests/Unit/Impl/RestStreamxClientBuilderTest.php
@@ -27,14 +27,14 @@ class RestStreamxClientBuilderTest extends MockServerTestCase
             StreamxResponse::success(836383, $key));
 
         $this->client = StreamxClientBuilders::create(self::$server->getServerRoot())
-            ->setIngestionEndpointUri('/custom-ingestion/v2')
+            ->setIngestionEndpointBaseUri('/custom-ingestion/v2')
             ->build();
 
         // When
         $result = $this->createPagesPublisher()->publish($key, $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/custom-ingestion/v2/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"message":"test"}'));
 
@@ -60,7 +60,7 @@ class RestStreamxClientBuilderTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->publish("key", $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/custom-requester-ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"message":"custom requester"}'));
 
@@ -109,7 +109,7 @@ class RestStreamxClientBuilderTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->publish($key, $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"message":"custom http client"}'),
             ['X-StreamX' => 'Custom http client']);
@@ -136,7 +136,7 @@ class RestStreamxClientBuilderTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->publish("key", $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"property":"original","customProperty":"Added by custom Json Provider"}'));
 

--- a/tests/Unit/Impl/RestStreamxClientIngestionTest.php
+++ b/tests/Unit/Impl/RestStreamxClientIngestionTest.php
@@ -18,7 +18,7 @@ use Streamx\Clients\Ingestion\Publisher\SuccessResult;
 use Streamx\Clients\Ingestion\Tests\Testing\MockServerTestCase;
 use Streamx\Clients\Ingestion\Tests\Testing\StreamxResponse;
 
-class RestStreamxClientTest extends MockServerTestCase
+class RestStreamxClientIngestionTest extends MockServerTestCase
 {
     private const LAST_REQUEST_OFFSET = -1;
 
@@ -37,7 +37,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->publish($key, $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key,
                 '{"data":{"name":"Data name","description":"Data description"},' .
@@ -60,7 +60,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->publish($key, $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"content":{"bytes":"Text"}}'));
 
@@ -87,7 +87,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->send($message);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             '{'.
                 '"key":"key-to-publish",'.
@@ -128,7 +128,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->unpublish($key);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultUnpublishMessageJson($key),
         );
@@ -155,7 +155,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->send($message);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             '{'.
                 '"key":"key-to-unpublish",'.
@@ -198,7 +198,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->send($message);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"name":"name","description":"content"}'));
 
@@ -227,12 +227,12 @@ class RestStreamxClientTest extends MockServerTestCase
         $this->createPagesPublisher()->unpublish($unpublishKey);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getRequestByOffset($this::LAST_REQUEST_OFFSET - 1),
+        $this->assertIngestionRequest(self::$server->getRequestByOffset($this::LAST_REQUEST_OFFSET - 1),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($publishKey, '{"name":"Test name","description":null}'),
             ['Authorization' => 'Bearer abc-100']);
 
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultUnpublishMessageJson($unpublishKey),
             ['Authorization' => 'Bearer abc-100']);
@@ -252,7 +252,7 @@ class RestStreamxClientTest extends MockServerTestCase
         $result = $this->createPagesPublisher()->publish($key, $data);
 
         // Then
-        $this->assertIngestionPostRequest(self::$server->getLastRequest(),
+        $this->assertIngestionRequest(self::$server->getLastRequest(),
             '/ingestion/v1/channels/pages/messages',
             $this->defaultPublishMessageJson($key, '{"message":"\u00a1Hola, \ud83c\udf0d!"}'));
 
@@ -584,7 +584,7 @@ class RestStreamxClientTest extends MockServerTestCase
 
         // Expect exception
         $this->expectException(StreamxClientException::class);
-        $this->expectExceptionMessage('POST request with URI: ' .
+        $this->expectExceptionMessage('Ingestion POST request with URI: ' .
             'https://non-existing/ingestion/v1/channels/errors/messages failed due to HTTP client error');
 
         // When
@@ -599,7 +599,7 @@ class RestStreamxClientTest extends MockServerTestCase
 
         // Expect exception
         $this->expectException(StreamxClientException::class);
-        $this->expectExceptionMessage('POST request with URI: ' .
+        $this->expectExceptionMessage('Ingestion POST request with URI: ' .
             'https://non-existing/ingestion/v1/channels/errors/messages failed due to HTTP client error');
 
         // When

--- a/tests/Unit/Impl/RestStreamxClientSchemaTest.php
+++ b/tests/Unit/Impl/RestStreamxClientSchemaTest.php
@@ -23,7 +23,7 @@ class RestStreamxClientSchemaTest extends MockServerTestCase
             StreamxResponse::custom(200, self::PAGES_SCHEMA_JSON));
 
         // When
-        $result = $this->createPagesPublisher()->getSchema();
+        $result = $this->createPagesPublisher()->fetchSchema();
 
         // Then
         $this->assertSchemaRequest(self::$server->getLastRequest(),
@@ -45,7 +45,7 @@ class RestStreamxClientSchemaTest extends MockServerTestCase
             StreamxResponse::custom(200, self::PAGES_SCHEMA_JSON));
 
         // When
-        $result = $this->createPagesPublisher()->getSchema();
+        $result = $this->createPagesPublisher()->fetchSchema();
 
         // Then
         $this->assertSchemaRequest(self::$server->getLastRequest(),
@@ -68,7 +68,7 @@ class RestStreamxClientSchemaTest extends MockServerTestCase
         $this->expectExceptionMessage('Authentication failed. Make sure that the given token is valid.');
 
         // When
-        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->getSchema();
+        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->fetchSchema();
     }
 
     /** @test */
@@ -83,7 +83,7 @@ class RestStreamxClientSchemaTest extends MockServerTestCase
         $this->expectExceptionMessage('Communication error. Response status: 500. Message: Internal Server Error');
 
         // When
-        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->getSchema();
+        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->fetchSchema();
     }
 
     /** @test */
@@ -98,6 +98,6 @@ class RestStreamxClientSchemaTest extends MockServerTestCase
             'https://non-existing' . self::ERRORS_SCHEMA_URL . ' failed due to HTTP client error');
 
         // When
-        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->getSchema();
+        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->fetchSchema();
     }
 }

--- a/tests/Unit/Impl/RestStreamxClientSchemaTest.php
+++ b/tests/Unit/Impl/RestStreamxClientSchemaTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Streamx\Clients\Ingestion\Tests\Unit\Impl;
+
+use Streamx\Clients\Ingestion\Builders\StreamxClientBuilders;
+use Streamx\Clients\Ingestion\Exceptions\StreamxClientException;
+use Streamx\Clients\Ingestion\Tests\Testing\MockServerTestCase;
+use Streamx\Clients\Ingestion\Tests\Testing\StreamxResponse;
+
+class RestStreamxClientSchemaTest extends MockServerTestCase
+{
+    private const PAGES_SCHEMA_URL = '/ingestion/v1/channels/pages/schema';
+    private const PAGES_SCHEMA_JSON = '{ "page" : { "field" : "value" } }';
+
+    private const ERRORS_SCHEMA_URL = '/ingestion/v1/channels/errors/schema';
+    private const ERRORS_CHANNEL = "errors";
+
+    /** @test */
+    public function shouldRetrieveChannelSchema()
+    {
+        // Given
+        self::$server->setResponseOfPath(self::PAGES_SCHEMA_URL,
+            StreamxResponse::custom(200, self::PAGES_SCHEMA_JSON));
+
+        // When
+        $result = $this->createPagesPublisher()->getSchema();
+
+        // Then
+        $this->assertSchemaRequest(self::$server->getLastRequest(),
+            self::PAGES_SCHEMA_URL,
+        );
+
+        $this->assertEquals(self::PAGES_SCHEMA_JSON, $result);
+    }
+
+    /** @test */
+    public function shouldRetrieveChannelSchemaWithAuthorizationToken()
+    {
+        // Given
+        $this->client = StreamxClientBuilders::create(self::$server->getServerRoot())
+            ->setAuthToken('abc-100')
+            ->build();
+
+        self::$server->setResponseOfPath(self::PAGES_SCHEMA_URL,
+            StreamxResponse::custom(200, self::PAGES_SCHEMA_JSON));
+
+        // When
+        $result = $this->createPagesPublisher()->getSchema();
+
+        // Then
+        $this->assertSchemaRequest(self::$server->getLastRequest(),
+            self::PAGES_SCHEMA_URL,
+            ['Authorization' => 'Bearer abc-100']
+        );
+
+        $this->assertEquals(self::PAGES_SCHEMA_JSON, $result);
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenUnauthorizedError()
+    {
+        // Given
+        self::$server->setResponseOfPath(self::ERRORS_SCHEMA_URL,
+            StreamxResponse::custom(401, ''));
+
+        // Expect exception
+        $this->expectException(StreamxClientException::class);
+        $this->expectExceptionMessage('Authentication failed. Make sure that the given token is valid.');
+
+        // When
+        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->getSchema();
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenServerError()
+    {
+        // Given
+        self::$server->setResponseOfPath(self::ERRORS_SCHEMA_URL,
+            StreamxResponse::custom(500, ''));
+
+        // Expect exception
+        $this->expectException(StreamxClientException::class);
+        $this->expectExceptionMessage('Communication error. Response status: 500. Message: Internal Server Error');
+
+        // When
+        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->getSchema();
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenNonExistingHost()
+    {
+        // Given
+        $this->client = StreamxClientBuilders::create('https://non-existing')->build();
+
+        // Expect exception
+        $this->expectException(StreamxClientException::class);
+        $this->expectExceptionMessage('Schema GET request with URI: ' .
+            'https://non-existing' . self::ERRORS_SCHEMA_URL . ' failed due to HTTP client error');
+
+        // When
+        $this->createPublisherWithIrrelevantSchema(self::ERRORS_CHANNEL)->getSchema();
+    }
+}

--- a/tests/Unit/Impl/StreamxClientIntegrationTest.php
+++ b/tests/Unit/Impl/StreamxClientIntegrationTest.php
@@ -150,8 +150,7 @@ class StreamxClientIntegrationTest extends TestCase {
         }
     }
 
-    public function verifyStreamxResponse(array $inputMessageKeys, array $ingestionEndpointResults): void
-    {
+    private function verifyStreamxResponse(array $inputMessageKeys, array $ingestionEndpointResults): void {
         $this->assertSameSize($inputMessageKeys, $ingestionEndpointResults);
         for ($i = 0; $i < count($ingestionEndpointResults); $i++) {
             $result = $ingestionEndpointResults[$i];
@@ -160,6 +159,24 @@ class StreamxClientIntegrationTest extends TestCase {
             $this->assertEquals($inputMessageKeys[$i], $result->getSuccess()->getKey());
             $this->assertIsInt($result->getSuccess()->getEventTime());
         }
+    }
+
+    //** @test */
+    public function shouldRetrieveChannelSchema() {
+        // when
+        $schemaJson = self::$publisher->getSchema();
+
+        // then
+        $schemaArray = json_decode($schemaJson, true);
+        $this->assertEquals('record', $schemaArray['type']);
+        $this->assertEquals('PageIngestionMessage', $schemaArray['name']);
+        $this->assertEquals('dev.streamx.blueprints.data', $schemaArray['namespace']);
+
+        $fieldNames = [];
+        foreach ($schemaArray['fields'] as $field) {
+            $fieldNames[] = $field['name'];
+        }
+        $this->assertEquals(['key', 'action', 'eventTime', 'properties', 'payload'], $fieldNames);
     }
 
     private function assertPageIsPublished(string $key) {

--- a/tests/Unit/Impl/StreamxClientIntegrationTest.php
+++ b/tests/Unit/Impl/StreamxClientIntegrationTest.php
@@ -162,9 +162,9 @@ class StreamxClientIntegrationTest extends TestCase {
     }
 
     //** @test */
-    public function shouldRetrieveChannelSchema() {
+    public function shouldFetchChannelSchema() {
         // when
-        $schemaJson = self::$publisher->getSchema();
+        $schemaJson = self::$publisher->fetchSchema();
 
         // then
         $schemaArray = json_decode($schemaJson, true);


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [x] Non-breaking change
- [ ] Bug fix / minor change

## 🛠 Changes being made

Implement method to retrieve channel schema in Ingestion Client.
This also required some naming refactors, since now we have base ingestion url, and two endpoints (actual ingestion, and schema info)

## ✅ Checklist

- [ ] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [x] Changed code is covered with unit tests
- [x] I have updated READMEs and java docs (if applicable)
